### PR TITLE
important overwrite background arrow for chaos theme

### DIFF
--- a/lib/ace/theme/chaos.css
+++ b/lib/ace/theme/chaos.css
@@ -120,7 +120,7 @@
 .ace-chaos .ace_fold-widget.ace_start,
 .ace-chaos .ace_fold-widget.ace_end,
 .ace-chaos .ace_fold-widget.ace_closed{
-  background: none;
+  background: none !important;
   border: none;
   box-shadow: none;
 }


### PR DESCRIPTION
Issue #4190

Fixes Chaos Theme many arrows in fold-widget end and close

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
